### PR TITLE
Bump runtime version

### DIFF
--- a/com.visualstudio.code.insiders.yaml
+++ b/com.visualstudio.code.insiders.yaml
@@ -1,9 +1,9 @@
 app-id: com.visualstudio.code.insiders
 default-branch: stable
 base: org.electronjs.Electron2.BaseApp
-base-version: '19.08'
+base-version: '20.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '19.08'
+runtime-version: '20.08'
 sdk: org.freedesktop.Sdk
 command: code-insiders
 tags: [proprietary]


### PR DESCRIPTION
The currently specified runtime is too old and was removed from flathub. So it's not possible to install this Flatpak. Safely bump the runtime version will make it work.