### PR TITLE
Disable x-checker

### DIFF
--- a/com.visualstudio.code.insiders.yaml
+++ b/com.visualstudio.code.insiders.yaml
@@ -17,7 +17,6 @@ finish-args:
   - --socket=ssh-auth
   - --share=network
   - --device=all
-  - --filesystem=xdg-config/gtk-3.0
   - --filesystem=host
   - --allow=devel
   - --talk-name=org.freedesktop.Notifications

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
   "only-arches": ["x86_64"],
-  "automerge-flathubbot-prs": true
+  "automerge-flathubbot-prs": true,
+  "disable-external-data-checker": true
 }


### PR DESCRIPTION
The last commit by the maintainer @fooishbar was 2 years ago https://github.com/flathub/com.visualstudio.code.insiders/commit/29161191fef62e4666b4ea075f9097024dbe1d17 and ever since then the package is getting automated updates from the x-checker while being on an outdated runtime.

Disable x-checker until it receives manual maintenance again as burning CI for no reason is not right