### PR TITLE
Support extensions for com.visualstudio.code

### DIFF
--- a/com.visualstudio.code.insiders.yaml
+++ b/com.visualstudio.code.insiders.yaml
@@ -25,7 +25,7 @@ finish-args:
   - --talk-name=com.canonical.AppMenu.Registrar.*
   - --system-talk-name=org.freedesktop.login1
 add-extensions:
-  com.visualstudio.code.insiders.tool:
+  com.visualstudio.code.tool:
     directory: tools
     subdirectories: true
     version: '23.08'


### PR DESCRIPTION
There are only extensions for com.visualstudio.code which should support both the release and insiders versions. As pointed out in https://github.com/flathub/flathub/pull/4125#issuecomment-1535231682, the extension point of the insiders flatpak should be the same as the release version.